### PR TITLE
CameraWrapper: Disable face detection for ZSL on JB cam

### DIFF
--- a/modules/camerawrapper/CameraWrapper.cpp
+++ b/modules/camerawrapper/CameraWrapper.cpp
@@ -146,6 +146,7 @@ char * camera_fixup_setparams(int id, const char * settings)
     const char *zsl = params.get(android::CameraParameters::KEY_ZSL);
     if (!zslValues && zsl && *zsl && !strncmp(zsl, "on", 2)) {
         params.set("mode", "high-quality-zsl");
+        params.set(android::CameraParameters::KEY_FACE_DETECTION, "off");
     }
 
     android::String8 strParams = params.flatten();


### PR DESCRIPTION
- face detection enabled causes crash in frameproc for ZSL shots
  after flash has been used and then turned off (JB camera)
  JIRA: CYAN-5583

Change-Id: Ieed01654b3a4c6dc3d267cff366fd1589eabe96f
